### PR TITLE
Update `ons_deaths` table

### DIFF
--- a/analysis/ehrql/dataset_definition_ehrql_example.py
+++ b/analysis/ehrql/dataset_definition_ehrql_example.py
@@ -33,9 +33,7 @@ date_range = (earliest_date, latest_date)
 
 dataset = Dataset()
 
-last_ons_death = ons_deaths.sort_by(ons_deaths.date).last_for_patient()
-
-dod_ons = last_ons_death.date
+dod_ons = ons_deaths.date
 
 has_died = dod_ons.is_on_or_between(*date_range)
 
@@ -56,13 +54,13 @@ dataset.define_population(
 ## Key cohort variables ##
 
 ## ONS date of death
-dataset.dod_ons = last_ons_death.date
+dataset.dod_ons = ons_deaths.date
 
 ## ONS place of death
-dataset.pod_ons = last_ons_death.place
+dataset.pod_ons = ons_deaths.place
 
 ## ONS cause of death
-dataset.cod_ons = last_ons_death.underlying_cause_of_death
+dataset.cod_ons = ons_deaths.underlying_cause_of_death
 
 ## Demographics ##
 

--- a/analysis/os_reports/dataset_definition_os_reports.py
+++ b/analysis/os_reports/dataset_definition_os_reports.py
@@ -32,9 +32,7 @@ date_range = (earliest_date, latest_date)
 
 dataset = Dataset()
 
-last_ons_death = ons_deaths.sort_by(ons_deaths.date).last_for_patient()
-
-dod_ons = last_ons_death.date
+dod_ons = ons_deaths.date
 
 has_died = dod_ons.is_on_or_between(*date_range)
 
@@ -55,13 +53,13 @@ dataset.define_population(
 ## Key cohort variables ##
 
 ## ONS date of death
-dataset.dod_ons = last_ons_death.date
+dataset.dod_ons = ons_deaths.date
 
 ## ONS place of death
-dataset.pod_ons = last_ons_death.place
+dataset.pod_ons = ons_deaths.place
 
 ## ONS cause of death
-dataset.cod_ons = last_ons_death.underlying_cause_of_death
+dataset.cod_ons = ons_deaths.underlying_cause_of_death
 
 ## Demographics ##
 


### PR DESCRIPTION
The `ons_deaths` table is now a PatientFrame (with one row per patient) so it is no longer needed to select one event per patient. The `ons_deaths` table now includes the earliest registered death for each patient. Only very few patients have multiple registered deaths so this change is very unlikely to impact the results of the study.